### PR TITLE
lazily unpack nested raw json types

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -1,6 +1,7 @@
 package conflate
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -38,14 +39,20 @@ func mergeRecursive(ctx context, pToData, fromData interface{}) error {
 		}
 	}
 
+	toVal := pToVal.Elem()
+	toData := toVal.Interface()
+
 	if fromData == nil {
 		return nil
 	}
 
-	toVal := pToVal.Elem()
+	// unpack handle nested raw JSON types from the source data
+	if fromDataAsJson, isJson := fromData.(json.RawMessage); isJson {
+		if err := json.Unmarshal(fromDataAsJson, &fromData); err != nil {
+			return err
+		}
+	}
 	fromVal := reflect.ValueOf(fromData)
-
-	toData := toVal.Interface()
 
 	if toVal.Interface() == nil {
 		toVal.Set(fromVal)
@@ -227,4 +234,16 @@ func mergeDefaultRecursive(ctx context, toVal, fromVal reflect.Value, toData, fr
 	toVal.Set(fromVal)
 
 	return nil
+}
+
+func lazyUnmarshalAs[T any](input interface{}) (T, bool) {
+	// unpack json.RawMessage
+	if asRaw, isJsonRaw := input.(json.RawMessage); isJsonRaw {
+		if err := json.Unmarshal(asRaw, &input); err != nil {
+			output, ok := input.(T)
+			return output, ok
+		}
+	}
+	output, ok := input.(T)
+	return output, ok
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -86,6 +86,7 @@ func TestMerge_SimpleSlice(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, toData, []interface{}{1, 2, 3, 4, 4, 5, 6})
 }
+
 func TestMerge_SliceOfMapsWithId(t *testing.T) {
 	toData := []interface{}{
 		map[string]interface{}{"id": "4"},
@@ -105,6 +106,7 @@ func TestMerge_SliceOfMapsWithId(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, toData)
 }
+
 func TestMerge_SliceOfPrimitive(t *testing.T) {
 	toData := []interface{}{
 		"a",
@@ -142,6 +144,33 @@ func TestMerge_SliceOfEqualStructs(t *testing.T) {
 		someStruct{"a"},
 		someStruct{"b"},
 		someStruct{"c"},
+	}
+	err := merge(&toData, fromData)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, toData)
+}
+
+func TestMerge_NestedRawJSON(t *testing.T) {
+	toData := map[string]interface{}{
+		"a": map[string]interface{}{
+			"nested-a1": "a1",
+		},
+		"b": map[string]interface{}{
+			"nested-b1": "b1",
+		},
+	}
+	fromData := map[string]interface{}{
+		"a": json.RawMessage(`{"nested-a2": "a2"}`),
+		"b": json.RawMessage(`{"nested-b1": "b1-override"}`),
+	}
+	expected := map[string]interface{}{
+		"a": map[string]interface{}{
+			"nested-a1": "a1",
+			"nested-a2": "a2",
+		},
+		"b": map[string]interface{}{
+			"nested-b1": "b1-override",
+		},
 	}
 	err := merge(&toData, fromData)
 	assert.Nil(t, err)


### PR DESCRIPTION
in case the source structure has some json.RawMessage fields in there, it will fail type assertions; unpack the raw message from the source before performing the merge. this _only_ works on the source data. if the destination data has raw messages on it, the merge will fail.